### PR TITLE
Fix breakage test dispatch type mismatch

### DIFF
--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -2,7 +2,7 @@ name: Test against ponyc nightly
 
 on:
   repository_dispatch:
-    types: [shared-docker-linux-builders-updated]
+    types: [shared-docker-builders-updated]
 
 permissions:
   packages: read


### PR DESCRIPTION
The `repository_dispatch` type in `breakage-against-ponyc-latest.yml` was `shared-docker-linux-builders-updated`, but the sender (`ponylang/shared-docker`) dispatches `shared-docker-builders-updated`. This meant the breakage test never fired.

Fixes the type to match what the sender actually dispatches.

Closes #23