### PR TITLE
Add pony-lint CI workflow

### DIFF
--- a/.github/workflows/pony-lint.yml
+++ b/.github/workflows/pony-lint.yml
@@ -21,4 +21,4 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Lint
-        run: pony-lint
+        run: make lint

--- a/.github/workflows/pony-lint.yml
+++ b/.github/workflows/pony-lint.yml
@@ -1,0 +1,24 @@
+name: pony-lint
+
+on:
+  pull_request:
+    paths:
+      - '**/*.pony'
+
+concurrency:
+  group: pony-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  packages: read
+
+jobs:
+  pony-lint:
+    name: Lint Pony source
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Lint
+        run: pony-lint

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ GET_DEPENDENCIES_WITH := corral fetch
 CLEAN_DEPENDENCIES_WITH := corral clean
 COMPILE_WITH := corral run -- ponyc
 BUILD_DOCS_WITH := corral run -- pony-doc
+LINT_WITH := corral run -- pony-lint
 
 BUILD_DIR ?= build/$(config)
 COVERAGE_DIR ?= build/coverage
@@ -49,6 +50,10 @@ $(EXAMPLES_BINARIES): $(BUILD_DIR)/%: $(SOURCE_FILES) $(EXAMPLES_SOURCE_FILES) |
 	$(GET_DEPENDENCIES_WITH)
 	$(PONYC) -o $(BUILD_DIR) $(EXAMPLES_DIR)/$*
 
+lint:
+	$(GET_DEPENDENCIES_WITH)
+	$(LINT_WITH) .
+
 clean:
 	$(CLEAN_DEPENDENCIES_WITH)
 	rm -rf $(BUILD_DIR)
@@ -79,4 +84,4 @@ $(BUILD_DIR):
 $(COVERAGE_DIR):
 	mkdir -p $(COVERAGE_DIR)
 
-.PHONY: all examples clean docs TAGS test coverage test-one
+.PHONY: all examples clean docs lint TAGS test coverage test-one

--- a/examples/simple-example/main.pony
+++ b/examples/simple-example/main.pony
@@ -4,4 +4,5 @@ use "../../logger"
 
 actor Main
   new create(env: Env) =>
-    env.out.print("we need at least 1 example. this one does nothing yet. want to contribute one?")
+    let logger = StringLogger(Fine, env.out)
+    logger(Info) and logger.log("hello from logger")

--- a/examples/simple-example/simple_example.pony
+++ b/examples/simple-example/simple_example.pony
@@ -1,0 +1,3 @@
+"""
+A minimal example that logs a message at the Info level.
+"""

--- a/logger/_logger_test.pony
+++ b/logger/_logger_test.pony
@@ -1,0 +1,31 @@
+use "pony_test"
+use "promises"
+
+trait \nodoc\ _LoggerTest[A] is UnitTest
+  fun apply(h: TestHelper) =>
+    let promise = Promise[String]
+    promise.next[None](recover this~_fulfill(h) end)
+
+    let stream = _TestStream(h, promise)
+
+    log(logger(level(), stream, _TestFormatter))
+
+    stream.logged()
+    h.long_test(2_000_000_000) // 2 second timeout
+
+  fun tag _fulfill(h: TestHelper, value: String) =>
+    h.assert_eq[String](value, expected())
+    h.complete(true)
+
+  fun timed_out(h: TestHelper) =>
+    h.complete(false)
+
+  fun logger(level': LogLevel,
+    stream': OutStream,
+    formatter': LogFormatter): Logger[A]
+
+  fun level(): LogLevel
+
+  fun tag expected(): String
+
+  fun log(logger': Logger[A])

--- a/logger/_string_logger_test.pony
+++ b/logger/_string_logger_test.pony
@@ -1,0 +1,8 @@
+trait \nodoc\ _StringLoggerTest is _LoggerTest[String]
+  fun logger(
+    level': LogLevel,
+    stream': OutStream,
+    formatter': LogFormatter)
+    : Logger[String]
+  =>
+    StringLogger(level', stream', formatter')

--- a/logger/_test.pony
+++ b/logger/_test.pony
@@ -1,5 +1,4 @@
 use "pony_test"
-use "promises"
 
 actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
@@ -90,79 +89,3 @@ class \nodoc\ _TestObjectLogging is _LoggerTest[U64]
 
   fun log(logger': Logger[U64]) =>
     logger'(Error) and logger'.log(U64(42))
-
-primitive \nodoc\ _TestFormatter is LogFormatter
-  fun apply(msg: String, loc: SourceLoc): String =>
-    msg + "\n"
-
-actor \nodoc\ _TestStream is OutStream
-  let _output: String ref = String
-  let _h: TestHelper
-  let _promise: Promise[String]
-
-  new create(h: TestHelper, promise: Promise[String]) =>
-    _h = h
-    _promise = promise
-
-  be print(data: ByteSeq) =>
-    _collect(data)
-
-  be write(data: ByteSeq) =>
-    _collect(data)
-
-  be printv(data: ByteSeqIter) =>
-    for bytes in data.values() do
-      _collect(bytes)
-    end
-
-  be writev(data: ByteSeqIter) =>
-    for bytes in data.values() do
-      _collect(bytes)
-    end
-
-  be flush() => None
-
-  fun ref _collect(data: ByteSeq) =>
-    _output.append(data)
-
-  be logged() =>
-    let s: String = _output.clone()
-    _promise(s)
-
-trait \nodoc\ _LoggerTest[A] is UnitTest
-  fun apply(h: TestHelper) =>
-    let promise = Promise[String]
-    promise.next[None](recover this~_fulfill(h) end)
-
-    let stream = _TestStream(h, promise)
-
-    log(logger(level(), stream, _TestFormatter))
-
-    stream.logged()
-    h.long_test(2_000_000_000) // 2 second timeout
-
-  fun tag _fulfill(h: TestHelper, value: String) =>
-    h.assert_eq[String](value, expected())
-    h.complete(true)
-
-  fun timed_out(h: TestHelper) =>
-    h.complete(false)
-
-  fun logger(level': LogLevel,
-    stream': OutStream,
-    formatter': LogFormatter): Logger[A]
-
-  fun level(): LogLevel
-
-  fun tag expected(): String
-
-  fun log(logger': Logger[A])
-
-trait \nodoc\ _StringLoggerTest is _LoggerTest[String]
-  fun logger(
-    level': LogLevel,
-    stream': OutStream,
-    formatter': LogFormatter)
-    : Logger[String]
-  =>
-    StringLogger(level', stream', formatter')

--- a/logger/_test_formatter.pony
+++ b/logger/_test_formatter.pony
@@ -1,0 +1,3 @@
+primitive \nodoc\ _TestFormatter is LogFormatter
+  fun apply(msg: String, loc: SourceLoc): String =>
+    msg + "\n"

--- a/logger/_test_stream.pony
+++ b/logger/_test_stream.pony
@@ -1,0 +1,36 @@
+use "pony_test"
+use "promises"
+
+actor \nodoc\ _TestStream is OutStream
+  let _output: String ref = String
+  let _h: TestHelper
+  let _promise: Promise[String]
+
+  new create(h: TestHelper, promise: Promise[String]) =>
+    _h = h
+    _promise = promise
+
+  be print(data: ByteSeq) =>
+    _collect(data)
+
+  be write(data: ByteSeq) =>
+    _collect(data)
+
+  be printv(data: ByteSeqIter) =>
+    for bytes in data.values() do
+      _collect(bytes)
+    end
+
+  be writev(data: ByteSeqIter) =>
+    for bytes in data.values() do
+      _collect(bytes)
+    end
+
+  be flush() => None
+
+  fun ref _collect(data: ByteSeq) =>
+    _output.append(data)
+
+  be logged() =>
+    let s: String = _output.clone()
+    _promise(s)

--- a/logger/log_formatter.pony
+++ b/logger/log_formatter.pony
@@ -1,0 +1,39 @@
+interface val LogFormatter
+  """
+  Interface required to implement custom log formatting.
+
+  * `msg` is the logged message
+  * `loc` is the location log was called from
+
+  See `DefaultLogFormatter` for an example of how to implement a LogFormatter.
+  """
+  fun apply(msg: String, loc: SourceLoc): String
+    """
+    Format `msg` with the source location in `loc`.
+    """
+
+primitive DefaultLogFormatter is LogFormatter
+  """
+  Formats log messages as `file:line:column: message`.
+  """
+  fun apply(msg: String, loc: SourceLoc): String =>
+    """
+    Return `msg` prefixed with `file:line:column: `.
+    """
+    let file_name: String = loc.file()
+    let file_linenum: String  = loc.line().string()
+    let file_linepos: String  = loc.pos().string()
+
+    (recover String(file_name.size()
+      + file_linenum.size()
+      + file_linepos.size()
+      + msg.size()
+      + 4)
+    end)
+      .> append(file_name)
+      .> append(":")
+      .> append(file_linenum)
+      .> append(":")
+      .> append(file_linepos)
+      .> append(": ")
+      .> append(msg)

--- a/logger/logger.pony
+++ b/logger/logger.pony
@@ -96,18 +96,33 @@ type LogLevel is
   )
 
 primitive Fine
+  """
+  Finest-grained log level.
+  """
   fun apply(): U32 => 0
 
 primitive Info
+  """
+  Informational log level.
+  """
   fun apply(): U32 => 1
 
 primitive Warn
+  """
+  Warning log level.
+  """
   fun apply(): U32 => 2
 
 primitive Error
+  """
+  Error log level.
+  """
   fun apply(): U32 => 3
 
 class val Logger[A]
+  """
+  Logs values of type `A`, converting them to strings via a supplied lambda.
+  """
   let _level: LogLevel
   let _out: OutStream
   let _f: {(A): String} val
@@ -132,6 +147,9 @@ class val Logger[A]
     true
 
 primitive StringLogger
+  """
+  Convenience constructor for a `Logger[String]`.
+  """
   fun apply(
     level: LogLevel,
     out: OutStream,
@@ -139,34 +157,3 @@ primitive StringLogger
     : Logger[String]
   =>
     Logger[String](level, out, {(s: String): String => s }, formatter)
-
-interface val LogFormatter
-  """
-  Interface required to implement custom log formatting.
-
-  * `msg` is the logged message
-  * `loc` is the location log was called from
-
-  See `DefaultLogFormatter` for an example of how to implement a LogFormatter.
-  """
-  fun apply(msg: String, loc: SourceLoc): String
-
-primitive DefaultLogFormatter is LogFormatter
-  fun apply(msg: String, loc: SourceLoc): String =>
-    let file_name: String = loc.file()
-    let file_linenum: String  = loc.line().string()
-    let file_linepos: String  = loc.pos().string()
-
-    (recover String(file_name.size()
-      + file_linenum.size()
-      + file_linepos.size()
-      + msg.size()
-      + 4)
-    end)
-     .> append(file_name)
-     .> append(":")
-     .> append(file_linenum)
-     .> append(":")
-     .> append(file_linepos)
-     .> append(": ")
-     .> append(msg)


### PR DESCRIPTION
Run pony-lint on PRs that touch .pony files, matching the setup used across other ponylang projects. Fix existing lint issues: split types into separate files to satisfy file-naming rules, add missing docstrings, fix indentation, replace placeholder example with a working one.