### PR TITLE
Update to work with Pony 0.69.0

### DIFF
--- a/.github/workflows/pony-lint.yml
+++ b/.github/workflows/pony-lint.yml
@@ -17,7 +17,7 @@ jobs:
     name: Lint Pony source
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,7 @@ jobs:
     name: Test against recent ponyc nightly on Linux
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-pcre:nightly
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-pcre:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,11 +17,11 @@ permissions:
   packages: read
 
 jobs:
-  vs-ponyc-release-linux:
-    name: Test against recent ponyc release on Linux
+  vs-ponyc-nightly-linux:
+    name: Test against recent ponyc nightly on Linux
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-pcre:release
+      image: ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-pcre:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Test

--- a/.release-notes/update-for-pony-0.69.0.md
+++ b/.release-notes/update-for-pony-0.69.0.md
@@ -1,0 +1,3 @@
+## Update to work with Pony 0.69.0
+
+Pony 0.69.0 is the new minimum required version.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Logger is ready for production use
 
 ## Installation
 
+* Requires ponyc 0.69.0 or later.
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/logger.git --version 1.0.1`
 * `corral fetch` to fetch your dependencies

--- a/logger/log_formatter.pony
+++ b/logger/log_formatter.pony
@@ -24,11 +24,11 @@ primitive DefaultLogFormatter is LogFormatter
     let file_linenum: String  = loc.line().string()
     let file_linepos: String  = loc.pos().string()
 
-    (recover String(file_name.size()
-      + file_linenum.size()
-      + file_linepos.size()
-      + msg.size()
-      + 4)
+    (recover String(file_name.size() +
+      file_linenum.size() +
+      file_linepos.size() +
+      msg.size() +
+      4)
     end)
       .> append(file_name)
       .> append(":")


### PR DESCRIPTION
Fix pony-lint operator-spacing violations, declare ponyc 0.69.0 as the minimum required version, and switch PR CI to nightly until 0.69.0 releases.