### PR TITLE
Restore pre-release state after the lint-only 0.69.0 pass

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,11 +17,11 @@ permissions:
   packages: read
 
 jobs:
-  vs-ponyc-nightly-linux:
-    name: Test against recent ponyc nightly on Linux
+  vs-ponyc-release-linux:
+    name: Test against recent ponyc release on Linux
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-pcre:nightly
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-pcre:release
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Test

--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,4 +1,0 @@
-## Update to work with Pony 0.69.0
-
-Pony 0.69.0 is the new minimum required version.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Changed
 
-- Update to work with Pony 0.69.0 ([PR #53](https://github.com/ponylang/logger/pull/53))
 
 ## [1.0.1] - 2022-02-26
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Logger is ready for production use
 
 ## Installation
 
-* Requires ponyc 0.69.0 or later.
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/logger.git --version 1.0.1`
 * `corral fetch` to fetch your dependencies


### PR DESCRIPTION
The Pony 0.69.0 prep PR (#53) was lint fixes and CI configuration only; nothing user-facing changed. Removes the release note, the CHANGELOG entry, and the `Requires ponyc 0.69.0 or later` README bullet, and reverts pr.yml from :nightly back to :release (pony-lint.yml stays on :nightly because release pony-lint doesn't understand the new operator-spacing conventions).