### PR TITLE
Add lock.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 _repos/
 _corral/
-build/
+build/lock.json


### PR DESCRIPTION
`lock.json` is generated by `corral fetch` and should not be checked in.